### PR TITLE
修复新版Chrome无法使用的bug

### DIFF
--- a/options.html
+++ b/options.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+
 <html>
 
 <head>


### PR DESCRIPTION
我在删除<!DOCTYPE html> 后可以在新版Chrome中加载