### PR TITLE
feat: enhance send2Local, support Get Put request method, and support…

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -859,5 +859,11 @@
   },
   "manualSend": {
     "message": "Automatic data transmission"
+  },
+  "requestMethod": {
+    "message": "Request Method"
+  },
+  "requestBody": {
+    "message": "Request Body"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -853,5 +853,11 @@
   },
   "setWhiteList": {
     "message": "ホワイトリストに設定"
+  },
+  "requestMethod": {
+    "message": "リクエストモード"
+  },
+  "requestBody": {
+    "message": "要求体"
   }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -859,5 +859,11 @@
   },
   "manualSend": {
     "message": "Transmissão automática de dados"	
+  },
+  "requestMethod": {
+    "message": "Método de pedido"
+  },
+  "requestBody": {
+    "message": "Corpo pedido"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -859,5 +859,11 @@
   },
   "manualSend": {
     "message": "手动发送"
+  },
+  "requestMethod": {
+    "message": "请求方式"
+  },
+  "requestBody": {
+    "message": "请求体"
   }
 }

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -859,5 +859,11 @@
   },
   "manualSend": {
     "message": "手動發送"
+  },
+  "requestMethod": {
+    "message": "請求管道"
+  },
+  "requestBody": {
+    "message": "請求體"
   }
 }

--- a/js/init.js
+++ b/js/init.js
@@ -75,6 +75,11 @@ G.OptionLists = {
         { "type": "ig", "regex": "https://cache\\.video\\.[a-z]*\\.com/dash\\?tvid=.*", "ext": "json", "state": false },
         { "type": "ig", "regex": ".*\\.bilivideo\\.(com|cn).*\\/live-bvc\\/.*m4s", "ext": "", "blackList": true, "state": false },
     ],
+    MethodMap: {
+        0: 'GET',
+        1: 'POST',
+        2: 'PUT'
+    },
     TitleName: false,
     Player: "",
     ShowWebIco: true,
@@ -106,6 +111,8 @@ G.OptionLists = {
     send2local: false,
     send2localManual: false,
     send2localURL: "http://127.0.0.1:8000/",
+    send2localMethod: 1,
+    send2localBody: '{"action": "$action", "data": "$data", "tabId": "$tabId"}',
     popup: false,
     popupHeight: 720,
     popupWidth: 1280,

--- a/options.html
+++ b/options.html
@@ -259,9 +259,26 @@
               </label>
             </div>
           </div>
+
+          <div class="item">
+            <div><span data-i18n-outer="requestMethod"></span> </div>
+            <div class="switch switchSelect">
+              <select id="send2localMethod" class="select" save="select">
+                <option value="0">GET</option>
+                <option value="1">POST</option>
+                <option value="2">PUT</option>
+              </select>
+            </div>
+          </div>
+
           <div class="item">
             <div><span data-i18n-outer="address"></span></div>
             <input id="send2localURL" save="input" type="text" class="width100"></input>
+          </div>
+
+          <div class="item">
+            <div><span data-i18n-outer="requestBody"></span></div>
+            <textarea id="send2localBody" save="input" type="text" class="width100 break-all" rows="3"></textarea>
           </div>
 
           <div class="flex-end">


### PR DESCRIPTION
增强“数据发送”发送功能，支持PUT,GET 请求方式，支持自定义请求体

`$data.url`表示 data 变量下面的 url 参数。并且支持路径查找例如：`$data.requestHeaders.origin`

$符号表示为变量，如果为固定文本参数，直接写参数 exp: "tm": "123"

```json
{
  "url": "$data.url", 
  "name": "$data.name", 
  "tabId": "$tabId"
}
```

请求方式的`map`已经配置在 init.js 的常量内
代码内预留了扩展请求方式的空间：`function.js/send2local`