### PR TITLE
Fix: Incorrect User-Agent header format causes aria2 download failures

### DIFF
--- a/js/pupup-utils.js
+++ b/js/pupup-utils.js
@@ -67,7 +67,7 @@ function aria2AddUri(data, success, error) {
     const params = { out: data.downFileName };
     if (G.enableAria2RpcReferer) {
         params.header = [];
-        params.header.push(G.userAgent ? G.userAgent : navigator.userAgent);
+        params.header.push("User-Agent: " + (G.userAgent ? G.userAgent : navigator.userAgent));
         if (data.requestHeaders?.referer) {
             params.header.push("Referer: " + data.requestHeaders.referer);
         }


### PR DESCRIPTION
### Issue
When enableAria2RpcReferer is enabled, downloads via aria2 RPC fail with HTTP 400 error.

<img width="3486" height="1176" alt="image" src="https://github.com/user-attachments/assets/1be74943-b021-4ee5-a264-5353008bf66f" />

<img width="2882" height="434" alt="image" src="https://github.com/user-attachments/assets/e8feac2e-cea1-439a-8c51-748b550e59a6" />

### Root Cause
The User-Agent header is missing the required prefix, preventing aria2 from parsing it correctly.

**Current code (incorrect):**
```javascript
params.header.push(G.userAgent ? G.userAgent : navigator.userAgent);
```

**Should be:**
```javascript
params.header.push("User-Agent: " + (G.userAgent ? G.userAgent : navigator.userAgent));
```

### Explanation
According to aria2, all headers follow the `"Header-Name: value"` format. The current code correctly formats `Referer` and `Cookie` headers, but the `User-Agent` is missing the prefix.
https://github.com/aria2/aria2/blob/master/src/HttpRequest.cc#L280-L284
https://github.com/aria2/aria2/blob/master/src/HttpRequest.cc#L268-L272