### PR TITLE
feat: add CSS selector support for extracting element text to filename

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -323,6 +323,24 @@
   "customSaveFileName": {
     "message": "Custom Save File Name"
   },
+  "cssSelectorOption": {
+    "message": "CSS Selector (extract element text to ${selectorText})"
+  },
+  "cssSelectorTips": {
+    "message": "Set different CSS selectors based on URL patterns, supports wildcards * and ?"
+  },
+  "cssSelectorUrlTips": {
+    "message": "Pattern, e.g.: *example.com/watch*"
+  },
+  "urlMatchPattern": {
+    "message": "URL Match Pattern"
+  },
+  "cssSelector": {
+    "message": "CSS Selector"
+  },
+  "addSelector": {
+    "message": "Add Selector"
+  },
   "userAgentTip": {
     "message": "Default to the current browser's User Agent"
   },
@@ -358,6 +376,9 @@
   },
   "customFilenameOption": {
     "message": "Use a custom filename to save the file (the default is the webpage title)"
+  },
+  "getHtmlDOMOption": {
+    "message": "Allow fetching page DOM (for CSS/XPath selector filename extraction)"
   },
   "saveAsOption": {
     "message": "Choose the save directory after downloading"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -323,6 +323,24 @@
   "customSaveFileName": {
     "message": "自定义保存文件名"
   },
+  "cssSelectorOption": {
+    "message": "CSS选择器 (提取元素文本到${selectorText})"
+  },
+  "cssSelectorTips": {
+    "message": "根据网址匹配规则设置不同的CSS选择器，支持通配符 * 和 ?"
+  },
+  "cssSelectorUrlTips": {
+    "message": "匹配模式，如: *example.com/watch*"
+  },
+  "urlMatchPattern": {
+    "message": "URL匹配模式"
+  },
+  "cssSelector": {
+    "message": "CSS选择器"
+  },
+  "addSelector": {
+    "message": "添加选择器"
+  },
   "userAgentTip": {
     "message": "留空默认为当前浏览器 User Agent"
   },
@@ -358,6 +376,9 @@
   },
   "customFilenameOption": {
     "message": "使用自定义文件名保存文件(默认为网页标题)"
+  },
+  "getHtmlDOMOption": {
+    "message": "允许获取页面DOM(用于CSS/XPath选择器提取文件名)"
   },
   "saveAsOption": {
     "message": "下载完选择保存目录"

--- a/js/function.js
+++ b/js/function.js
@@ -261,6 +261,9 @@ function templatesFunction(text, action, data) {
             }
         } else if (action == "find") {
             text = "";
+            // 支持 CSS 选择器和 XPath
+            const selector = arg[0];
+            const type = arg[1] || "css";  // 第二个参数指定类型: css 或 xpath
             if (data.pageDOM) {
                 try {
                     text = data.pageDOM.querySelector(arg[0]).innerText?.trim();
@@ -310,6 +313,7 @@ function templates(text, data) {
         pageDOM: data.pageDOM,
         cookie: data.cookie ?? "",
         tabId: data.tabId ?? 0,
+        selectorText: data.selectorText ?? "",
 
         // 时间相关
         year: date.getFullYear(),

--- a/js/init.js
+++ b/js/init.js
@@ -138,6 +138,7 @@ G.OptionLists = {
     saveAs: false,
     userAgent: "",
     downFileName: "${title}.${ext}",
+    cssSelector: [],    // CSS选择器规则列表，每项包含 url(匹配模式), selector(CSS选择器), state(是否启用)
     css: "",
     checkDuplicates: true,
     enable: true,
@@ -283,6 +284,10 @@ function InitOptions() {
         items.blockUrl = items.blockUrl.map(item => {
             return { url: wildcardToRegex(item.url), state: item.state }
         });
+        // 预编译CSS选择器URL匹配规则
+        items.cssSelector = items.cssSelector.map(item => {
+            return { url: wildcardToRegex(item.url), selector: item.selector, state: item.state }
+        });
 
         // 兼容旧配置
         if (items.copyM3U8.includes('$url$')) {
@@ -355,6 +360,12 @@ chrome.storage.onChanged.addListener(function (changes, namespace) {
         if (key == "blockUrl") {
             G.blockUrl = newValue.map(item => {
                 return { url: wildcardToRegex(item.url), state: item.state }
+            });
+            continue;
+        }
+        if (key == "cssSelector") {
+            G.cssSelector = newValue.map(item => {
+                return { url: wildcardToRegex(item.url), selector: item.selector, state: item.state }
             });
             continue;
         }

--- a/js/options.js
+++ b/js/options.js
@@ -32,6 +32,10 @@ chrome.storage.sync.get(G.OptionLists, function (items) {
     for (let key in items.blockUrl) {
         $blockUrlList.append(Gethtml("blockUrl", { url: items.blockUrl[key].url, state: items.blockUrl[key].state }));
     }
+    const $cssSelectorList = $("#cssSelectorList");
+    for (let key in items.cssSelector) {
+        $cssSelectorList.append(Gethtml("cssSelector", { url: items.cssSelector[key].url, selector: items.cssSelector[key].selector, state: items.cssSelector[key].state }));
+    }
     setTimeout(() => {
         for (let key in items) {
             if (key == "Ext" || key == "Type" || key == "Regex") { continue; }
@@ -60,6 +64,10 @@ $("#AddRegex").bind("click", function () {
 $("#blockAddUrl").bind("click", function () {
     $("#blockUrlList").append(Gethtml("blockUrl", { state: true }));
     $("#blockUrlList [name=url]").last().focus();
+});
+$("#addCssSelector").bind("click", function () {
+    $("#cssSelectorList").append(Gethtml("cssSelector", { state: true }));
+    $("#cssSelectorList [name=url]").last().focus();
 });
 $("#version").html(i18n.catCatch + " v" + chrome.runtime.getManifest().version);
 
@@ -105,6 +113,10 @@ function Gethtml(Type, Param = new Object()) {
             break;
         case "blockUrl":
             html = `<td><input type="text" value="${Param.url ? Param.url : ""}" name="url" placeholder="${i18n.blockUrlTips}" class="width100"></td>`
+            break;
+        case "cssSelector":
+            html = `<td><input type="text" value="${Param.url ? Param.url : ""}" name="url" placeholder="${i18n.cssSelectorUrlTips}" class="width100"></td>`
+            html += `<td><input type="text" value="${Param.selector ? Param.selector : ""}" name="selector" placeholder="${i18n.cssSelector}" class="width100"></td>`
             break;
     }
     html = $(`<tr data-type="${Type}">
@@ -192,6 +204,8 @@ $("#allDisable, #allEnable").bind("click", function () {
         query = $("#regexList [name=state]");
     } else if (obj == "blockUrl") {
         query = $("#blockUrlList [name=state]");
+    } else if (obj == "cssSelector") {
+        query = $("#cssSelectorList [name=state]");
     }
     query.each(function () {
         $(this).prop("checked", state);
@@ -403,6 +417,19 @@ function Save(option, sec = 0) {
                 blockUrl.push({ url: url, state: GetState });
             });
             chrome.storage.sync.set({ blockUrl: blockUrl });
+            return;
+        }
+        if (option == "cssSelector") {
+            let cssSelector = new Array();
+            $("#cssSelectorList tr").each(function () {
+                const _this = $(this);
+                let url = _this.find("[name=url]").val();
+                let selector = _this.find("[name=selector]").val();
+                let GetState = _this.find("[name=state]").prop("checked");
+                if (isEmpty(url) || isEmpty(selector)) { return true; }
+                cssSelector.push({ url: url, selector: selector, state: GetState });
+            });
+            chrome.storage.sync.set({ cssSelector: cssSelector });
             return;
         }
     }, sec);

--- a/options.html
+++ b/options.html
@@ -450,6 +450,24 @@
             <textarea id="downFileName" save="input" type="text" class="width100"></textarea>
           </div>
           <div class="item">
+            <div data-i18n="cssSelectorOption"></div>
+            <span class="explain" data-i18n="cssSelectorTips"></span>
+          </div>
+          <table id="cssSelectorList">
+            <tr>
+              <th data-i18n="urlMatchPattern"></th>
+              <th data-i18n="cssSelector"></th>
+              <th data-i18n="enable"></th>
+              <th data-i18n="delete"></th>
+            </tr>
+          </table>
+          <div class="flex-end">
+            <button type="button" id="addCssSelector" class="button2" data-i18n="addSelector" title="add Selector"></button>
+            <button type="button" id="ResetCssSelector" data-reset="cssSelector" data-i18n="resetSettings" title="reset CSS Selector"></button>
+            <button type="button" id="allDisableCssSelector" data-switch="cssSelector" data-i18n="disableAll" title="disable All CSS Selector"></button>
+            <button type="button" id="allEnableCssSelector" data-switch="cssSelector" data-i18n="enableAll" title="enable All CSS Selector"></button>
+          </div>
+          <div class="item">
             <div>${userAgent} <span data-i18n-outer="userAgentTip"></span></div>
             <textarea id="userAgent" save="input" type="text" class="width100"></textarea>
           </div>
@@ -652,6 +670,16 @@
             <div class="switch">
               <label class="switchLabel switchRadius">
                 <input type="checkbox" save="click" id="TitleName" class="switchInput" />
+                <span class="switchRound switchRadius"><em class="switchRoundBtn switchRadius"></em></span>
+              </label>
+            </div>
+          </div>
+
+          <div class="item">
+            <div data-i18n="getHtmlDOMOption"></div>
+            <div class="switch">
+              <label class="switchLabel switchRadius">
+                <input type="checkbox" save="click" id="getHtmlDOM" class="switchInput" />
                 <span class="switchRound switchRadius"><em class="switchRoundBtn switchRadius"></em></span>
               </label>
             </div>


### PR DESCRIPTION
- Add cssSelector option in settings to define URL pattern-based CSS selector rules

- Support wildcard * and ? in URL matching patterns

- Extract element text using chrome.scripting.executeScript in background.js

- Add {selectorText} template variable for downFileName and m3u8dlArg

- Convert findMedia() to async function to support await executeScript

- Add localization strings for CSS selector feature in zh_CN and en


<img width="1770" height="420" alt="image" src="https://github.com/user-attachments/assets/c9e3978c-2846-47a2-bd9e-ea72b63c725f" />
