### PR TITLE
docs: update Chrome Web Store URL to new format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # 📖安装地址
 ## 🐴Chrome
-https://chrome.google.com/webstore/detail/jfedfbgedapdagkghmgibemcoggfppbb
+https://chromewebstore.google.com/detail/jfedfbgedapdagkghmgibemcoggfppbb
 ## 🦄Edge
 https://microsoftedge.microsoft.com/addons/detail/oohmdefbjalncfplafanlagojlakmjci
 ## 🦊Firefox


### PR DESCRIPTION
## What
Updates the Chrome Web Store link in README.md from the old format to the new format.

## Why
Google has migrated Chrome Web Store URLs from `chrome.google.com/webstore` to `chromewebstore.google.com`. This update ensures the link works correctly.

## How
- Changed: `chrome.google.com/webstore/detail/jfedfbgedapdagkghmgibemcoggfppbb` → `chromewebstore.google.com/detail/jfedfbgedapdagkghmgibemcoggfppbb`

## Testing
- Verified the URL structure follows the new format
- No other changes made