### PR TITLE
docs: fix outdated Chrome Web Store URL in 3 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # 📖安装地址
 ## 🐴Chrome
-https://chrome.google.com/webstore/detail/jfedfbgedapdagkghmgibemcoggfppbb
+https://chromewebstore.google.com/detail/jfedfbgedapdagkghmgibemcoggfppbb
 ## 🦄Edge
 https://microsoftedge.microsoft.com/addons/detail/oohmdefbjalncfplafanlagojlakmjci
 ## 🦊Firefox

--- a/README_en.md
+++ b/README_en.md
@@ -5,7 +5,7 @@ Cat-Catch is a resource sniffing extension that can help you filter and list the
 
 # 📖Installation
 ## 🐴Chrome
-https://chrome.google.com/webstore/detail/jfedfbgedapdagkghmgibemcoggfppbb
+https://chromewebstore.google.com/detail/jfedfbgedapdagkghmgibemcoggfppbb
 ## 🦄Edge
 https://microsoftedge.microsoft.com/addons/detail/oohmdefbjalncfplafanlagojlakmjci
 ## 🦊Firefox

--- a/README_es.md
+++ b/README_es.md
@@ -5,7 +5,7 @@ Cat-Catch es una extensión de rastreo de recursos que puede ayudarlo a filtrar 
 
 # 📖Instalación
 ## 🐴Chrome
-https://chrome.google.com/webstore/detail/jfedfbgedapdagkghmgibemcoggfppbb
+https://chromewebstore.google.com/detail/jfedfbgedapdagkghmgibemcoggfppbb
 ## 🦄Edge
 https://microsoftedge.microsoft.com/addons/detail/oohmdefbjalncfplafanlagojlakmjci
 ## 🦊Firefox


### PR DESCRIPTION
## What
Fixed outdated Chrome Web Store URL in 3 README files.

## Why
The old URL format `chrome.google.com/webstore` has been deprecated and redirects to `chromewebstore.google.com`. Updating directly improves user experience.

## Files fixed
- README.md
- README_en.md  
- README_es.md
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*