### PR TITLE
docs: update Chrome Web Store URLs to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # 📖安装地址
 ## 🐴Chrome
-https://chrome.google.com/webstore/detail/jfedfbgedapdagkghmgibemcoggfppbb
+https://chromewebstore.google.com/detail/jfedfbgedapdagkghmgibemcoggfppbb
 ## 🦄Edge
 https://microsoftedge.microsoft.com/addons/detail/oohmdefbjalncfplafanlagojlakmjci
 ## 🦊Firefox

--- a/README_en.md
+++ b/README_en.md
@@ -5,7 +5,7 @@ Cat-Catch is a resource sniffing extension that can help you filter and list the
 
 # 📖Installation
 ## 🐴Chrome
-https://chrome.google.com/webstore/detail/jfedfbgedapdagkghmgibemcoggfppbb
+https://chromewebstore.google.com/detail/jfedfbgedapdagkghmgibemcoggfppbb
 ## 🦄Edge
 https://microsoftedge.microsoft.com/addons/detail/oohmdefbjalncfplafanlagojlakmjci
 ## 🦊Firefox

--- a/README_es.md
+++ b/README_es.md
@@ -5,7 +5,7 @@ Cat-Catch es una extensión de rastreo de recursos que puede ayudarlo a filtrar 
 
 # 📖Instalación
 ## 🐴Chrome
-https://chrome.google.com/webstore/detail/jfedfbgedapdagkghmgibemcoggfppbb
+https://chromewebstore.google.com/detail/jfedfbgedapdagkghmgibemcoggfppbb
 ## 🦄Edge
 https://microsoftedge.microsoft.com/addons/detail/oohmdefbjalncfplafanlagojlakmjci
 ## 🦊Firefox


### PR DESCRIPTION
## Summary
- Updated 3 Chrome Web Store URLs from `chrome.google.com/webstore/detail/` to `chromewebstore.google.com/detail/` across 3 README files
- Google migrated the Chrome Web Store to a new domain; the old URLs currently redirect but may stop working in the future

## Files changed
- `README.md` (1 URL)
- `README_en.md` (1 URL)
- `README_es.md` (1 URL)

## Test plan
- [x] Verified all updated URLs resolve correctly
- [x] No functional changes, docs-only update