### PR TITLE
Update m3u8.js

### DIFF
--- a/js/m3u8.js
+++ b/js/m3u8.js
@@ -434,9 +434,11 @@ hls.on(Hls.Events.MANIFEST_PARSED, function (event, data) {
         const url = encodeURIComponent(item.uri ?? item.url);
         const referer = requestHeaders.referer ? "&requestHeaders=" + encodeURIComponent(JSON.stringify(requestHeaders)) : "&initiator=" + (_initiator ? encodeURIComponent(_initiator) : "");
         const title = _title ? encodeURIComponent(_title) : "";
+        const fileName = _fileName ? encodeURIComponent(_fileName) : "";
         const name = GetFile(item.uri ?? item.url);
         let newUrl = `/m3u8.html?url=${url}${referer}`;
         if (title) { newUrl += `&title=${title}`; }
+        if (fileName) { newUrl += `&filename=${fileName}`; }
         if (tabId) { newUrl += `&tabid=${tabId}`; }
         if (key) { newUrl += `&key=${key}`; }
         return [name, newUrl];


### PR DESCRIPTION
之前有提到过，如果点击“解析”后再点击“合并下载”，这种情况下文件名不会遵循“自定义保存文件名”。
https://x.com/Natural_Video4K/status/2008835148905947459


<img width="799" height="122" alt="image" src="https://github.com/user-attachments/assets/20ab1070-94ec-483d-8dd5-7e1bc39c8527" />
<img width="609" height="200" alt="image" src="https://github.com/user-attachments/assets/97e793e3-142e-460d-bce3-132069d8a0ec" />
<img width="429" height="81" alt="image" src="https://github.com/user-attachments/assets/1b13ae83-3ff4-4a25-b920-baa9b4077f26" />

<img width="425" height="82" alt="image" src="https://github.com/user-attachments/assets/3be071c7-e38d-4fc3-a8ac-3562a316cd7d" />
<img width="819" height="28" alt="image" src="https://github.com/user-attachments/assets/4cf628a3-3e83-4259-befc-a9cd0969fafd" />
