### PR TITLE
Fix removing items when "delete duplicate" is enabled

### DIFF
--- a/js/preview.js
+++ b/js/preview.js
@@ -269,10 +269,13 @@ class FilePreview {
     deleteItem(data = null) {
         data = data ? [data] : this.getSelectedItems();
         data.forEach(item => {
-            const index = this.originalItems.findIndex(originalItem => originalItem.requestId === item.requestId);
-            if (index !== -1) {
-                this.originalItems.splice(index, 1);
-            }
+            let index = -1
+            do {
+                index = this.originalItems.findIndex(originalItem => originalItem.requestId === item.requestId || (this.deleteDuplicateFilenames && originalItem.name === item.name));
+                if (index !== -1) {
+                    this.originalItems.splice(index, 1);
+                }
+            } while (index !== -1);
         });
         this.updateFileList();
     }


### PR DESCRIPTION
Without this change, enabling `Delete duplicate filenames` in the `popout` window would hide duplicate items, but would re-add the next hidden item to the list when removing the item that caused it to be hidden.

With this change, if `Delete duplicate filenames` is enabled when deleting an item, all items with matching names are deleted from the `originalItems` list as well, preventing them from being added to the `fileItems`.

This implementation allows enabling/disabling the `Delete duplicate filenames` checkbox to show duplicate items, and will only delete all duplicates if the setting is enabled at the time of deletion.